### PR TITLE
Updating Chai to 2.2.x and removing nodeJS 0.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - "0.11"
   - "0.10"
-  - "0.8"

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ before(function (done) {
 
 ## History
 
+* 1.2.0 - Removed nodeJS 0.8 and updated Chai to 2.2.x
 * 1.1.0 - Dependency update
 * 1.0.10 - AMD loader support
 * 1.0.9 - Published to bower.

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
 		"test/"
 	],
 	"dependencies": {
-		"tv4": "~1.0.16",
+		"tv4": "~1.1.x",
 		"jsonpointer.js": "~0.3.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-json-schema",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Chai plugin for JSON Schema v4",
   "author": {
     "name": "Bart van der Schoor",
@@ -32,7 +32,7 @@
   "main": "index.js",
   "readmeFilename": "README.md",
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 0.10.0"
   },
   "scripts": {
     "test": "grunt test"
@@ -44,7 +44,7 @@
   "devDependencies": {
     "grunt": "~0.4.2",
     "grunt-cli": "~0.1",
-    "chai": "~1.9.0",
+    "chai": "~2.0.x",
     "mocha": "~1.18.0",
     "grunt-mocha": "~0.4.10",
     "grunt-contrib-jshint": "~0.9.2",
@@ -56,6 +56,6 @@
     "requirejs": "~2.1.11"
   },
   "peerDependencies": {
-    "chai": ">= 1.6.1 < 2"
+    "chai": ">= 2.0.0 < 3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "grunt-contrib-jshint": "~0.11.x",
     "jshint-path-reporter": "~0.1",
     "grunt-continue": "0.0.1",
-    "grunt-mocha-test": "~0.10.0",
+    "grunt-mocha-test": "~0.12.x",
     "mocha-unfunk-reporter": "~0.4.0",
     "grunt-bump": "~0.3.x",
     "requirejs": "~2.1.11"

--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
   },
   "dependencies": {
     "jsonpointer.js": "0.3.0",
-    "tv4": "~1.0.16"
+    "tv4": "~1.1.x"
   },
   "devDependencies": {
     "grunt": "~0.4.2",
     "grunt-cli": "~0.1",
-    "chai": "~2.0.x",
+    "chai": "~2.2.x",
     "mocha": "~1.18.0",
     "grunt-mocha": "~0.4.10",
     "grunt-contrib-jshint": "~0.9.2",

--- a/package.json
+++ b/package.json
@@ -45,14 +45,14 @@
     "grunt": "~0.4.2",
     "grunt-cli": "~0.1",
     "chai": "~2.2.x",
-    "mocha": "~1.18.0",
+    "mocha": "~2.2.x",
     "grunt-mocha": "~0.4.10",
-    "grunt-contrib-jshint": "~0.9.2",
+    "grunt-contrib-jshint": "~0.11.x",
     "jshint-path-reporter": "~0.1",
     "grunt-continue": "0.0.1",
     "grunt-mocha-test": "~0.10.0",
     "mocha-unfunk-reporter": "~0.4.0",
-    "grunt-bump": "0.0.11",
+    "grunt-bump": "~0.3.x",
     "requirejs": "~2.1.11"
   },
   "peerDependencies": {


### PR DESCRIPTION
I've ran the tests using Travis-CI. Build successful and passing.
https://travis-ci.org/trickeyone/chai-json-schema/builds/58359210
