### PR TITLE
Fix deprecation warnings in tests

### DIFF
--- a/test/fail.js
+++ b/test/fail.js
@@ -22,7 +22,7 @@
       chai.use(plugin);
     }
     chai.should();
-    chai.Assertion.includeStack = true;
+    chai.config.includeStack = true;
 
     var assert = chai.assert;
 

--- a/test/suite.js
+++ b/test/suite.js
@@ -22,7 +22,7 @@
       chai.use(plugin);
     }
     chai.should();
-    chai.Assertion.includeStack = true;
+    chai.config.includeStack = true;
 
     var expect = chai.expect;
     var assert = chai.assert;


### PR DESCRIPTION
`chai.Assertion.includeStack` is deprecated, so let's move to `chai.config.includeStack`