### PR TITLE
Run travis in same node-versions as Chai itself does

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: node_js
 node_js:
-- '0.11'
-- '0.10'
+  - 0.10
+  - 0.12
+  - 4
+  - 6
+  - lts/*
+  - node
 deploy:
   provider: npm
   email:


### PR DESCRIPTION
### Context
The previous test setup did not cover the node versions Chai advertises. The node versions that Travis validates should match the Chai versions.

### What has been done
- Added all node versions in `.travis.yml`