### PR TITLE
update peer dependency requirement to include chai 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "requirejs": "^2.2.0"
   },
   "peerDependencies": {
-    "chai": ">= 1.6.1 < 4"
+    "chai": ">= 1.6.1 < 5"
   }
 }


### PR DESCRIPTION
### Context
Fixes #47 

### What has been done
- Updated the peer dependency requirement for chai to be < 5.    
This so chai-json-schema again installs without errors on npm versions <= 3 and chai versions >= 4.

### How to test
- run `npm test`

### What is _not_ in this PR
- development dependency update to chai 4:
  - chai 4 drops support for node 0.10 and 0.12, 
  - chai-json-schema still supports these as per package.json and the ci config
  - upping chai 4 would mean the build would fail on 0.10 and 0.12 => chai-json-schema would have to remove these from the build matrix and drop support for these versions. I'm not qualified to take that decision.
- A version bump    
Assuming this is done by a maintainer on triggering the release procedure