### PR TITLE
Remove support for node versions lower than 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: node_js
 node_js:
-  - 0.10
-  - 0.12
-  - 4
-  - 6
-  - lts/*
-  - node
+  - 6 # to be removed 2019-04-01
+  - 8 # to be removed 2019-12-31
+  - 9 # to be removed 2018-06-30
+  - lts/* # safety net; don't remove
+  - node # safety net; don't remove
 deploy:
   provider: npm
   email:

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "main": "./index",
   "engines": {
-    "node": ">= 4"
+    "node": ">= 6"
   },
   "scripts": {
     "test": "grunt test"
@@ -50,7 +50,7 @@
     "grunt-mocha": "^1.0.2",
     "grunt-mocha-test": "^0.13.2",
     "jshint-path-reporter": "^0.1.3",
-    "mocha": "^3.1.2",
+    "mocha": "^5.2.0",
     "mocha-unfunk-reporter": "^0.4.0",
     "requirejs": "^2.2.0"
   },


### PR DESCRIPTION
### Context
NodeJS version 6 is the lowest supported NodeJS version

### What has been done
- Removed support for versions lower than 6
- Updated Mocha

### Notes
Also closes #58 
