### PR TITLE
chore(deps): override serialize-javascript to ^7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1583,16 +1583,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -1627,35 +1617,14 @@
         "node": ">=4"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,9 @@
     "mocha": "^11.0.0",
     "prettier": "^3.0.0"
   },
+  "overrides": {
+    "serialize-javascript": "^7.0.5"
+  },
   "peerDependencies": {
     "chai": ">= 1.6.1 < 5"
   }


### PR DESCRIPTION
## Why

After #67 merged, Dependabot opened two new alerts on `master`:

- GHSA-5c6j-r48x-rmvq (high) — `serialize-javascript` RCE via `RegExp.flags` and `Date.prototype.toISOString()`
- GHSA-qj8w-gfj5-8c6v (medium) — `serialize-javascript` CPU exhaustion DoS

Both come in through `mocha@11.7.6 → serialize-javascript@6.0.2`. Mocha's latest release still pins `^6.0.2` and there's no upstream bump yet. The fix lives in `serialize-javascript@^7`.

Both alerts are dev-scope; consumers are unaffected. The runtime tarball stays byte-identical to 1.5.1.

## What

- Add `overrides.serialize-javascript: "^7.0.5"` to `package.json`.
- `package-lock.json` regenerated; `serialize-javascript@7.0.5` now resolves under `mocha`.

## Test plan

- [x] `npm install` exits clean.
- [x] `npm ls serialize-javascript` shows `7.0.5 overridden` under `mocha`.
- [x] `npm test` — all suites green (30 passing + 7 passing).
- [x] `npm audit --omit=dev` — 0.
- [x] `npm audit` no longer flags `serialize-javascript` (only the known mocha-transitive `diff` low-severity advisory remains, which Dependabot has already auto-dismissed).
- [x] CI matrix green on Node 18/20/22/24.