### PR TITLE
feat: switch to ESM only

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -38,8 +38,6 @@ export default [
   {
     files: ['index.js'],
     languageOptions: {
-      ecmaVersion: 5,
-      sourceType: 'script',
       globals: { ...nodeGlobals, ...browserGlobals }
     },
     rules: {
@@ -49,8 +47,6 @@ export default [
   {
     files: ['test/**/*.js'],
     languageOptions: {
-      ecmaVersion: 5,
-      sourceType: 'script',
       globals: { ...nodeGlobals, ...browserGlobals, ...mochaGlobals }
     },
     rules: {

--- a/index.js
+++ b/index.js
@@ -1,189 +1,159 @@
-(function () {
-  'use strict';
-  /*jshint -W003*/
+import tv4Module from 'tv4';
+import jsonpointer from 'jsonpointer.js';
 
-  if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
-    // NodeJS
-    module.exports = getPayload(
-      require('tv4'),
-      require('jsonpointer.js')
-    );
-  } else if (typeof define === 'function' && define.amd) {
-    // AMD
-    define('chai-json-schema', [
-      'tv4',
-      'jsonpointer'
-    ], function (tv4, jsonpointer) {
-      return getPayload(tv4, jsonpointer);
-    });
-  } else {
-    // Other environment (usually <script> tag): plug in to global chai instance directly.
-    chai.use(getPayload(
-      window.tv4,
-      window.jsonpointer
-    ));
+const tv4 = tv4Module.freshApi();
+tv4.cyclicCheck = false;
+tv4.banUnknown = false;
+tv4.multiple = false;
+
+export { tv4 };
+
+export default function pluginFn(chai, utils) {
+  const assert = chai.assert;
+  const flag = utils.flag;
+
+  // make a compact debug string from any object
+  function valueStrim(value, cutoff) {
+    const strimLimit = typeof cutoff === 'undefined' ? 60 : cutoff;
+
+    const t = typeof value;
+    if (t === 'function') {
+      return '[function]';
+    }
+    if (t === 'object') {
+      value = JSON.stringify(value);
+      if (value.length > strimLimit) {
+        value = value.substr(0, strimLimit) + '...';
+      }
+      return value;
+    }
+    if (t === 'string') {
+      if (value.length > strimLimit) {
+        return JSON.stringify(value.substr(0, strimLimit)) + '...';
+      }
+      return JSON.stringify(value);
+    }
+    return '' + value;
   }
 
-  function getPayload(tv4Module, jsonpointer) {
-    if (!tv4Module) throw new Error('chai-json-schema: tv4 dependency missing');
-    if (!jsonpointer) throw new Error('chai-json-schema: jsonpointer dependency missing');
+  function extractSchemaLabel(schema, max) {
+    max = typeof max === 'undefined' ? 40 : max;
+    let label = '';
+    if (schema.id) {
+      label = schema.id;
+    }
+    if (schema.title) {
+      label += label ? ' (' + schema.title + ')' : schema.title;
+    }
+    if (!label && schema.description) {
+      label = valueStrim(schema.description, max);
+    }
+    if (!label) {
+      label = valueStrim(schema, max);
+    }
+    return label;
+  }
 
-    var tv4 = tv4Module.freshApi();
-    tv4.cyclicCheck = false;
-    tv4.banUnknown = false;
-    tv4.multiple = false;
+  // print validation errors
+  const formatResult = function (error, data, schema, indent) {
+    let schemaValue;
+    let dataValue;
 
-    function pluginFn(chai, utils) {
-      var assert = chai.assert;
-      var flag = utils.flag;
+    // assemble error string
+    let ret = '';
+    ret += '\n' + indent + error.message;
 
-      function forEachI(arr, func, scope) {
-        for (var i = 0, ii = arr.length; i < ii; i++) {
-          func.call(scope, arr[i], i, arr);
-        }
-      }
-
-      // make a compact debug string from any object
-      function valueStrim(value, cutoff) {
-        var strimLimit = typeof cutoff === 'undefined' ? 60 : cutoff;
-
-        var t = typeof value;
-        if (t === 'function') {
-          return '[function]';
-        }
-        if (t === 'object') {
-          value = JSON.stringify(value);
-          if (value.length > strimLimit) {
-            value = value.substr(0, strimLimit) + '...';
-          }
-          return value;
-        }
-        if (t === 'string') {
-          if (value.length > strimLimit) {
-            return JSON.stringify(value.substr(0, strimLimit)) + '...';
-          }
-          return JSON.stringify(value);
-        }
-        return '' + value;
-      }
-
-      function extractSchemaLabel(schema, max) {
-        max = typeof max === 'undefined' ? 40 : max;
-        var label = '';
-        if (schema.id) {
-          label = schema.id;
-        }
-        if (schema.title) {
-          label += (label ? ' (' + schema.title + ')' : schema.title);
-        }
-        if (!label && schema.description) {
-          label = valueStrim(schema.description, max);
-        }
-        if (!label) {
-          label = valueStrim(schema, max);
-        }
-        return label;
-      }
-
-      // print validation errors
-      var formatResult = function (error, data, schema, indent) {
-        var schemaValue;
-        var dataValue;
-
-        // assemble error string
-        var ret = '';
-        ret += '\n' + indent + error.message;
-
-        var schemaLabel = extractSchemaLabel(schema, 60);
-        if (schemaLabel) {
-          ret += '\n' + indent + '    schema: ' + schemaLabel;
-        }
-        if (error.schemaPath) {
-          schemaValue = jsonpointer.get(schema, error.schemaPath);
-          ret += '\n' + indent + '    rule:   ' + error.schemaPath + ' -> ' + valueStrim(schemaValue);
-        }
-        if (error.dataPath) {
-          dataValue = jsonpointer.get(data, error.dataPath);
-          ret += '\n' + indent + '    field:  ' + error.dataPath + ' -> ' + utils.type(dataValue) + ': ' + valueStrim(dataValue);
-        }
-
-        // sub errors are not implemented (yet?)
-        // https://github.com/chaijs/chai-json-schema/issues/3
-        /*if (error.subErrors) {
-         forEachI(error.subErrors, function (error) {
-         ret += formatResult(error, data, schema, indent + indent);
-         });
-         }*/
-        return ret;
-      };
-
-      // add the method
-      chai.Assertion.addMethod('jsonSchema', function (schema, msg) {
-        if (msg) {
-          flag(this, 'message', msg);
-        }
-        var obj = this._obj;
-
-        // note: don't assert.ok(obj) -> zero or empty string is a valid and describable json-value
-        assert.ok(schema, 'schema');
-
-        // single result
-        var result = null;
-        if (tv4.multiple) {
-          result = tv4.validateMultiple(obj, schema, tv4.cyclicCheck, tv4.banUnknown);
-        } else {
-          result = tv4.validateResult(obj, schema, tv4.cyclicCheck, tv4.banUnknown);
-        }
-        // assertion fails on missing schemas
-        var pass = result.valid && (result.missing.length === 0);
-
-        // assemble readable message
-        var label = extractSchemaLabel(schema, 30);
-
-        // assemble error report
-        var details = '';
-        if (!pass) {
-          var indent = '      ';
-          details += ' -> \'' + valueStrim(obj, 30) + '\'';
-
-          if (result.error) {
-            details += formatResult(result.error, obj, schema, indent);
-          }
-          else if (result.errors) {
-            forEachI(result.errors, function (error) {
-              details += formatResult(error, obj, schema, indent);
-            });
-          }
-
-          if (result.missing.length === 1) {
-            details += '\n' + 'missing 1 schema: ' + result.missing[0];
-          }
-          else if (result.missing.length > 0) {
-            details += '\n' + 'missing ' + result.missing.length + ' schemas:';
-            forEachI(result.missing, function (missing) {
-              details += '\n' + missing;
-            });
-          }
-        }
-        // pass hardcoded strings and no actual value (mocha forces nasty string diffs)
-        this.assert(
-          pass
-          , 'expected value to match json-schema \'' + label + '\'' + details
-          , 'expected value not to match json-schema \'' + label + '\'' + details
-          , label
-        );
-      });
-
-      // export tdd style
-      assert.jsonSchema = function (val, exp, msg) {
-        new chai.Assertion(val, msg).to.be.jsonSchema(exp);
-      };
-      assert.notJsonSchema = function (val, exp, msg) {
-        new chai.Assertion(val, msg).to.not.be.jsonSchema(exp);
-      };
+    let schemaLabel = extractSchemaLabel(schema, 60);
+    if (schemaLabel) {
+      ret += '\n' + indent + '    schema: ' + schemaLabel;
+    }
+    if (error.schemaPath) {
+      schemaValue = jsonpointer.get(schema, error.schemaPath);
+      ret += '\n' + indent + '    rule:   ' + error.schemaPath + ' -> ' + valueStrim(schemaValue);
+    }
+    if (error.dataPath) {
+      dataValue = jsonpointer.get(data, error.dataPath);
+      ret +=
+        '\n' +
+        indent +
+        '    field:  ' +
+        error.dataPath +
+        ' -> ' +
+        utils.type(dataValue) +
+        ': ' +
+        valueStrim(dataValue);
     }
 
-    pluginFn.tv4 = tv4;
-    return pluginFn;
-  }
-}());
+    // sub errors are not implemented (yet?)
+    // https://github.com/chaijs/chai-json-schema/issues/3
+    /*if (error.subErrors) {
+     forEachI(error.subErrors, function (error) {
+     ret += formatResult(error, data, schema, indent + indent);
+     });
+     }*/
+    return ret;
+  };
+
+  // add the method
+  chai.Assertion.addMethod('jsonSchema', function (schema, msg) {
+    if (msg) {
+      flag(this, 'message', msg);
+    }
+    const obj = this._obj;
+
+    // note: don't assert.ok(obj) -> zero or empty string is a valid and describable json-value
+    assert.ok(schema, 'schema');
+
+    // single result
+    let result = null;
+    if (tv4.multiple) {
+      result = tv4.validateMultiple(obj, schema, tv4.cyclicCheck, tv4.banUnknown);
+    } else {
+      result = tv4.validateResult(obj, schema, tv4.cyclicCheck, tv4.banUnknown);
+    }
+    // assertion fails on missing schemas
+    const pass = result.valid && result.missing.length === 0;
+
+    // assemble readable message
+    const label = extractSchemaLabel(schema, 30);
+
+    // assemble error report
+    let details = '';
+    if (!pass) {
+      const indent = '      ';
+      details += " -> '" + valueStrim(obj, 30) + "'";
+
+      if (result.error) {
+        details += formatResult(result.error, obj, schema, indent);
+      } else if (result.errors) {
+        for (const error of result.errors) {
+          details += formatResult(error, obj, schema, indent);
+        }
+      }
+
+      if (result.missing.length === 1) {
+        details += '\n' + 'missing 1 schema: ' + result.missing[0];
+      } else if (result.missing.length > 0) {
+        details += '\n' + 'missing ' + result.missing.length + ' schemas:';
+        for (const missing of result.missing) {
+          details += '\n' + missing;
+        }
+      }
+    }
+    // pass hardcoded strings and no actual value (mocha forces nasty string diffs)
+    this.assert(
+      pass,
+      "expected value to match json-schema '" + label + "'" + details,
+      "expected value not to match json-schema '" + label + "'" + details,
+      label
+    );
+  });
+
+  // export tdd style
+  assert.jsonSchema = function (val, exp, msg) {
+    new chai.Assertion(val, msg).to.be.jsonSchema(exp);
+  };
+  assert.notJsonSchema = function (val, exp, msg) {
+    new chai.Assertion(val, msg).to.not.be.jsonSchema(exp);
+  };
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "chai-json-schema",
   "version": "2.0.0",
   "description": "Chai plugin for JSON Schema v4",
+  "type": "module",
   "author": {
     "name": "Bart van der Schoor",
     "url": "https://github.com/chaijs"
@@ -29,7 +30,7 @@
   "bugs": {
     "url": "https://github.com/chaijs/chai-json-schema/issues"
   },
-  "main": "./index",
+  "main": "./index.js",
   "files": [
     "index.js",
     "LICENSE-MIT",

--- a/test/fail.js
+++ b/test/fail.js
@@ -1,166 +1,149 @@
-(function () {
-  'use strict';
-  /*jshint -W003*/
-  if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
-    // NodeJS
-    getPayload(require('chai'), require('../index'));
-  } else if (typeof define === 'function' && define.amd) {
-    // AMD
-    define([
-      'chai',
-      'chai-json-schema',
-    ], function (chai, plugin) {
-      return getPayload(chai, plugin);
+import * as chai from 'chai';
+import plugin from '../index.js';
+
+chai.use(plugin);
+chai.should();
+chai.config.includeStack = true;
+
+const assert = chai.assert;
+
+describe('chai-json-schema fail demo', function () {
+  chai.use(function (chai, utils) {
+    const inspect = utils.objDisplay;
+    chai.Assertion.addMethod('fail', function (message) {
+      const obj = this._obj;
+
+      new chai.Assertion(obj).is.a('function');
+
+      try {
+        obj();
+      } catch (err) {
+        this.assert(
+          err instanceof chai.AssertionError,
+          message + ' expected #{this} to fail, but it threw ' + inspect(err)
+        );
+        return;
+      }
+
+      this.assert(false, message + ' expected #{this} to fail');
     });
-  } else {
-    // Other environment (usually <script> tag): plug in to global chai instance directly.
-    return getPayload(window.chai, null);
-  }
-
-  function getPayload(chai, plugin) {
-    if (plugin) {
-      chai.use(plugin);
-    }
-    chai.should();
-    chai.config.includeStack = true;
-
-    var assert = chai.assert;
-
-    describe('chai-json-schema fail demo', function () {
-      chai.use(function (chai, utils) {
-        var inspect = utils.objDisplay;
-        chai.Assertion.addMethod('fail', function (message) {
-          var obj = this._obj;
-
-          new chai.Assertion(obj).is.a('function');
-
-          try {
-            obj();
-          } catch (err) {
-            this.assert(
-              err instanceof chai.AssertionError
-              , message + ' expected #{this} to fail, but it threw ' + inspect(err));
-            return;
+  });
+  const tests = [
+    {
+      name: 'properties',
+      schema: {
+        properties: {
+          intKey: {
+            type: 'integer'
+          },
+          stringKey: {
+            type: 'string'
           }
-
-          this.assert(false, message + ' expected #{this} to fail');
-        });
-      });
-      var tests = [{
-        name: 'properties',
-        schema: {
-          properties: {
-            intKey: {
-              type: 'integer'
-            },
-            stringKey: {
-              type: 'string'
-            }
-          }
-        },
-        valid: [{
+        }
+      },
+      valid: [
+        {
           data: {
             intKey: 1,
             stringKey: 'one'
           }
-        }],
-        invalid: [{
+        }
+      ],
+      invalid: [
+        {
           data: {
             intKey: 3,
             stringKey: false
           }
-        }]
-      }, {
-        name: 'combinations',
-        schema: {
-          id: 'any_v1',
-          anyOf: [
-            { type: 'integer' },
-            { type: 'string' }
-          ]
-        },
-        valid: [
-          { data: 1 },
-          { data: 'yo' }
-        ],
-        invalid: [
-          { data: [1, 2, 3] },
-          { data: { aa: 1 } }
-        ]
-      }, {
-        name: 'fruit',
-        schema: {
-          id: 'fruit_v1',
-          description: 'fresh fruit schema v1',
-          type: 'object',
-          properties: {
-            required: ['skin', 'colors', 'taste'],
-            colors: {
-              type: 'array',
-              minItems: 1,
-              uniqueItems: true,
-              items: {
-                type: 'string'
-              }
-            },
-            skin: {
+        }
+      ]
+    },
+    {
+      name: 'combinations',
+      schema: {
+        id: 'any_v1',
+        anyOf: [{ type: 'integer' }, { type: 'string' }]
+      },
+      valid: [{ data: 1 }, { data: 'yo' }],
+      invalid: [{ data: [1, 2, 3] }, { data: { aa: 1 } }]
+    },
+    {
+      name: 'fruit',
+      schema: {
+        id: 'fruit_v1',
+        description: 'fresh fruit schema v1',
+        type: 'object',
+        properties: {
+          required: ['skin', 'colors', 'taste'],
+          colors: {
+            type: 'array',
+            minItems: 1,
+            uniqueItems: true,
+            items: {
               type: 'string'
-            },
-            taste: {
-              type: 'number',
-              minimum: 5
             }
+          },
+          skin: {
+            type: 'string'
+          },
+          taste: {
+            type: 'number',
+            minimum: 5
           }
-        },
-        valid: [{
+        }
+      },
+      valid: [
+        {
           data: {
             skin: 'thin',
             colors: ['red', 'green', 'yellow'],
             taste: 10
           }
-        }],
-        invalid: [{
+        }
+      ],
+      invalid: [
+        {
           data: {
             colors: ['brown'],
             taste: 0,
             worms: 2
           }
-        }]
-      }];
+        }
+      ]
+    }
+  ];
 
-      it('has tests', function () {
-        assert.isArray(tests, 'tests');
-        assert.operator(tests.length, '>', 0, 'tests.length');
+  it('has tests', function () {
+    assert.isArray(tests, 'tests');
+    assert.operator(tests.length, '>', 0, 'tests.length');
+  });
+
+  Object.keys(tests).forEach(function (key) {
+    const testCase = tests[key];
+    describe('test ' + testCase.name, function () {
+      it('has settings', function () {
+        assert.isObject(testCase.schema, 'schema');
+
+        assert.isArray(testCase.valid, 'valid');
+        assert.operator(testCase.valid.length, '>', 0, 'valid.length');
+
+        assert.isArray(testCase.invalid, 'invalid');
+        assert.operator(testCase.invalid.length, '>', 0, 'invalid.length');
       });
+    });
+  });
 
-      Object.keys(tests).forEach(function (key) {
-        var testCase = tests[key];
-        describe('test ' + testCase.name, function () {
-          it('has settings', function () {
-            assert.isObject(testCase.schema, 'schema');
-
-            assert.isArray(testCase.valid, 'valid');
-            assert.operator(testCase.valid.length, '>', 0, 'valid.length');
-
-            assert.isArray(testCase.invalid, 'invalid');
-            assert.operator(testCase.invalid.length, '>', 0, 'invalid.length');
-          });
-        });
-      });
-
-      // enable this to see the error reporting
-      describe('bulk', function () {
-        Object.keys(tests).forEach(function (key) {
-          var testCase = tests[key];
-          describe(testCase.name + ' schema', function () {
-            it('assert.jsonSchema()', function () {
-              testCase.invalid.forEach(function (obj, i) {
-                assert.notJsonSchema(obj.data, testCase.schema, '#' + i);
-              });
-            });
+  // enable this to see the error reporting
+  describe('bulk', function () {
+    Object.keys(tests).forEach(function (key) {
+      const testCase = tests[key];
+      describe(testCase.name + ' schema', function () {
+        it('assert.jsonSchema()', function () {
+          testCase.invalid.forEach(function (obj, i) {
+            assert.notJsonSchema(obj.data, testCase.schema, '#' + i);
           });
         });
       });
     });
-  }
-}());
+  });
+});

--- a/test/suite.js
+++ b/test/suite.js
@@ -1,326 +1,321 @@
-(function () {
-  'use strict';
-  /*jshint -W003*/
-  if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
-    // NodeJS
-    getPayload(require('chai'), require('../index'));
-  } else if (typeof define === 'function' && define.amd) {
-    // AMD
-    define([
-      'chai',
-      'chai-json-schema',
-    ], function (chai, plugin) {
-      return getPayload(chai, plugin);
+import * as chai from 'chai';
+import { default as plugin, tv4 } from '../index.js';
+
+chai.use(plugin);
+chai.should();
+chai.config.includeStack = true;
+
+const expect = chai.expect;
+const assert = chai.assert;
+
+describe('chai-json-schema', function () {
+  chai.use(function (chai, utils) {
+    const inspect = utils.objDisplay;
+
+    chai.Assertion.addMethod('fail', function (message) {
+      const obj = this._obj;
+
+      new chai.Assertion(obj).is.a('function');
+
+      try {
+        obj();
+      } catch (err) {
+        this.assert(
+          err instanceof chai.AssertionError,
+          message + ' expected #{this} to fail, but it threw ' + inspect(err)
+        );
+        return;
+      }
+
+      this.assert(false, message + ' expected #{this} to fail');
     });
-  } else {
-    // Other environment (usually <script> tag): plug in to global chai instance directly.
-    return getPayload(window.chai, null);
-  }
+  });
 
-  function getPayload(chai, plugin) {
-    if (plugin) {
-      chai.use(plugin);
-    }
-    chai.should();
-    chai.config.includeStack = true;
+  describe('api', function () {
+    it('exposes a live tv4 instance with expected methods', function () {
+      assert.isObject(tv4, 'tv4');
+      assert.isFunction(tv4.addSchema, 'tv4.addSchema');
+      assert.isFunction(tv4.getMissingUris, 'tv4.getMissingUris');
+      assert.isFunction(tv4.validateResult, 'tv4.validateResult');
+      assert.isFunction(tv4.validateMultiple, 'tv4.validateMultiple');
+      assert.isFunction(tv4.freshApi, 'tv4.freshApi');
+    });
+    it('jsonpointer is live: error output includes field path for invalid data', function () {
+      const schema = { properties: { x: { type: 'integer' } } };
+      const invalid = { x: 'not-an-int' };
+      let msg = null;
+      try {
+        assert.jsonSchema(invalid, schema);
+      } catch (err) {
+        msg = err.message;
+      }
+      assert.ok(msg, 'expected an assertion error');
+      assert.include(msg, '/x', 'jsonpointer resolved field path in error output');
+    });
+  });
 
-    var expect = chai.expect;
-    var assert = chai.assert;
-
-    describe('chai-json-schema', function () {
-      chai.use(function (chai, utils) {
-        var inspect = utils.objDisplay;
-
-        chai.Assertion.addMethod('fail', function (message) {
-          var obj = this._obj;
-
-          new chai.Assertion(obj).is.a('function');
-
-          try {
-            obj();
-          } catch (err) {
-            this.assert(
-              err instanceof chai.AssertionError
-              , message + ' expected #{this} to fail, but it threw ' + inspect(err));
-            return;
-          }
-
-          this.assert(false, message + ' expected #{this} to fail');
-        });
-      });
-
-      describe('api', function () {
-        it('exposes a live tv4 instance with expected methods', function () {
-          assert.isObject(plugin.tv4, 'plugin.tv4');
-          assert.isFunction(plugin.tv4.addSchema, 'plugin.tv4.addSchema');
-          assert.isFunction(plugin.tv4.getMissingUris, 'plugin.tv4.getMissingUris');
-          assert.isFunction(plugin.tv4.validateResult, 'plugin.tv4.validateResult');
-          assert.isFunction(plugin.tv4.validateMultiple, 'plugin.tv4.validateMultiple');
-          assert.isFunction(plugin.tv4.freshApi, 'plugin.tv4.freshApi');
-        });
-        it('jsonpointer is live: error output includes field path for invalid data', function () {
-          var schema = { properties: { x: { type: 'integer' } } };
-          var invalid = { x: 'not-an-int' };
-          var msg = null;
-          try {
-            assert.jsonSchema(invalid, schema);
-          } catch (err) {
-            msg = err.message;
-          }
-          assert.ok(msg, 'expected an assertion error');
-          assert.include(msg, '/x', 'jsonpointer resolved field path in error output');
-        });
-      });
-
-      describe('assertions', function () {
-        var tests = [{
-          name: 'properties',
-          schema: {
-            properties: {
-              intKey: {
-                type: 'integer'
-              },
-              stringKey: {
-                type: 'string'
-              }
+  describe('assertions', function () {
+    const tests = [
+      {
+        name: 'properties',
+        schema: {
+          properties: {
+            intKey: {
+              type: 'integer'
+            },
+            stringKey: {
+              type: 'string'
             }
-          },
-          valid: [{
+          }
+        },
+        valid: [
+          {
             data: {
               intKey: 1,
               stringKey: 'one'
             }
-          }],
-          invalid: [{
+          }
+        ],
+        invalid: [
+          {
             data: {
               intKey: 'three',
               stringKey: false
             }
-          }]
-        }, {
-          name: 'fruit',
-          schema: {
-            id: 'fruit_v1',
-            description: 'fresh fruit schema v1',
-            type: 'object',
-            required: ['skin', 'colors', 'taste'],
-            properties: {
-              colors: {
-                type: 'array',
-                minItems: 1,
-                uniqueItems: true,
-                items: {
-                  type: 'string'
-                }
-              },
-              skin: {
+          }
+        ]
+      },
+      {
+        name: 'fruit',
+        schema: {
+          id: 'fruit_v1',
+          description: 'fresh fruit schema v1',
+          type: 'object',
+          required: ['skin', 'colors', 'taste'],
+          properties: {
+            colors: {
+              type: 'array',
+              minItems: 1,
+              uniqueItems: true,
+              items: {
                 type: 'string'
-              },
-              taste: {
-                type: 'number',
-                minimum: 5
-              },
-              worms: {
-                type: 'number',
-                maximum: 1
               }
+            },
+            skin: {
+              type: 'string'
+            },
+            taste: {
+              type: 'number',
+              minimum: 5
+            },
+            worms: {
+              type: 'number',
+              maximum: 1
             }
-          },
-          valid: [{
+          }
+        },
+        valid: [
+          {
             data: {
               skin: 'thin',
               colors: ['red', 'green', 'yellow'],
               taste: 10
             }
-          }, {
+          },
+          {
             data: {
               skin: 'thin',
               colors: ['yellow'],
               taste: 5,
               worms: 1
             }
-          }],
-          invalid: [{
+          }
+        ],
+        invalid: [
+          {
             data: {
               skin: 'thin',
               colors: ['yellow'],
               taste: 0,
               worms: 2
             }
-          }, {
+          },
+          {
             data: {
               skin: 'thin',
               colors: [1, 2, 3],
               taste: 4
             }
-          }, {
+          },
+          {
             data: {
               skin: 321,
               colors: ['yellow', 'yellow'],
               taste: 5
             }
-          }, { data: {
+          },
+          {
+            data: {
               skin: 'thin',
               colors: ['yellow'],
               taste: 4,
               worms: 3
             }
-          }]
-        }];
-        describe('check test data', function () {
-          it('has tests', function () {
-            assert.isArray(tests, 'tests');
-            assert.operator(tests.length, '>', 0, 'tests.length');
-          });
+          }
+        ]
+      }
+    ];
+    describe('check test data', function () {
+      it('has tests', function () {
+        assert.isArray(tests, 'tests');
+        assert.operator(tests.length, '>', 0, 'tests.length');
+      });
 
-          Object.keys(tests).forEach(function (key) {
-            var testCase = tests[key];
-            describe('test ' + testCase.name, function () {
-              it('has settings', function () {
-                assert.isObject(testCase.schema, 'schema');
+      Object.keys(tests).forEach(function (key) {
+        const testCase = tests[key];
+        describe('test ' + testCase.name, function () {
+          it('has settings', function () {
+            assert.isObject(testCase.schema, 'schema');
 
-                assert.isArray(testCase.valid, 'valid');
-                assert.operator(testCase.valid.length, '>', 0, 'valid.length');
+            assert.isArray(testCase.valid, 'valid');
+            assert.operator(testCase.valid.length, '>', 0, 'valid.length');
 
-                assert.isArray(testCase.invalid, 'invalid');
-                assert.operator(testCase.invalid.length, '>', 0, 'invalid.length');
-              });
-            });
+            assert.isArray(testCase.invalid, 'invalid');
+            assert.operator(testCase.invalid.length, '>', 0, 'invalid.length');
           });
         });
+      });
+    });
 
-        describe('bdd', function () {
+    describe('bdd', function () {
+      it('is defined', function () {
+        assert.isFunction(expect(true).to.be.jsonSchema, 'expect jsonSchema');
+        assert.isFunction({}.should.be.jsonSchema, 'should jsonSchema');
+      });
 
-          it('is defined', function () {
-            assert.isFunction(expect(true).to.be.jsonSchema, 'expect jsonSchema');
-            assert.isFunction({}.should.be.jsonSchema, 'should jsonSchema');
+      Object.keys(tests).forEach(function (key) {
+        const testCase = tests[key];
+        describe(testCase.name + ' schema', function () {
+          it('should/expect', function () {
+            testCase.valid.forEach(function (obj, i) {
+              expect(obj.data).to.be.jsonSchema(testCase.schema, 'expect() #' + i);
+              obj.data.should.be.jsonSchema(testCase.schema, 'should #' + i);
+            });
+          });
+          it('should/expect negation', function () {
+            testCase.invalid.forEach(function (obj, i) {
+              expect(obj.data).to.not.be.jsonSchema(testCase.schema, 'expect() #' + i);
+              obj.data.should.not.be.jsonSchema(testCase.schema, 'should #' + i);
+            });
           });
 
-          Object.keys(tests).forEach(function (key) {
-            var testCase = tests[key];
-            describe(testCase.name + ' schema', function () {
-              it('should/expect', function () {
-                testCase.valid.forEach(function (obj, i) {
+          it('should/expect fails on invalid', function () {
+            testCase.invalid.forEach(function (obj, i) {
+              expect(function () {
+                expect(obj.data).to.be.jsonSchema(testCase.schema, 'expect() #' + i);
+                obj.data.should.be.jsonSchema(testCase.schema, 'should #' + i);
+              }).to.fail('#' + i);
+            });
+          });
+
+          it('should/expect fails negation on valid', function () {
+            testCase.valid.forEach(function (obj, i) {
+              expect(function () {
+                expect(obj.data).to.not.be.jsonSchema(testCase.schema, 'expect() #' + i);
+                obj.data.should.not.be.jsonSchema(testCase.schema, 'should #' + i);
+              }).to.fail('#' + i);
+            });
+          });
+          it('should/expect output single negation', function () {
+            testCase.invalid.forEach(function (obj, i) {
+              expect(function () {
+                expect(obj.data).to.be.jsonSchema(testCase.schema, 'expect() #' + i);
+              }).to.throw(/(.+?\n){4}/);
+              expect(function () {
+                obj.data.should.be.jsonSchema(testCase.schema, 'should #' + i);
+              }).to.throw(/(.+?\n){4}/);
+            });
+          });
+          describe('should/expect output multiple negation', function () {
+            before(function () {
+              tv4.multiple = true;
+            });
+            after(function () {
+              tv4.multiple = false;
+            });
+            it('should/expect multiple negation', function () {
+              testCase.invalid.forEach(function (obj, i) {
+                expect(function () {
                   expect(obj.data).to.be.jsonSchema(testCase.schema, 'expect() #' + i);
+                }).to.throw(/(.+?\n){5,}/);
+                expect(function () {
                   obj.data.should.be.jsonSchema(testCase.schema, 'should #' + i);
-                });
-              });
-              it('should/expect negation', function () {
-                testCase.invalid.forEach(function (obj, i) {
-                  expect(obj.data).to.not.be.jsonSchema(testCase.schema, 'expect() #' + i);
-                  obj.data.should.not.be.jsonSchema(testCase.schema, 'should #' + i);
-                });
-              });
-
-              it('should/expect fails on invalid', function () {
-                testCase.invalid.forEach(function (obj, i) {
-                  expect(function () {
-                    expect(obj.data).to.be.jsonSchema(testCase.schema, 'expect() #' + i);
-                    obj.data.should.be.jsonSchema(testCase.schema, 'should #' + i);
-                  }).to.fail('#' + i);
-                });
-              });
-
-              it('should/expect fails negation on valid', function () {
-                testCase.valid.forEach(function (obj, i) {
-                  expect(function () {
-                    expect(obj.data).to.not.be.jsonSchema(testCase.schema, 'expect() #' + i);
-                    obj.data.should.not.be.jsonSchema(testCase.schema, 'should #' + i);
-                  }).to.fail('#' + i);
-                });
-              });
-              it('should/expect output single negation', function () {
-                testCase.invalid.forEach(function (obj, i) {
-                  expect(function () {
-                    expect(obj.data).to.be.jsonSchema(testCase.schema, 'expect() #' + i);
-                  }).to.throw(/(.+?\n){4}/);
-                  expect(function () {
-                    obj.data.should.be.jsonSchema(testCase.schema, 'should #' + i);
-                  }).to.throw(/(.+?\n){4}/);
-                });
-              });
-              describe('should/expect output multiple negation', function () {
-                before(function () {
-                  plugin.tv4.multiple = true;
-                });
-                after(function () {
-                  plugin.tv4.multiple = false;
-                });
-                it('should/expect multiple negation', function () {
-                  testCase.invalid.forEach(function (obj, i) {
-                    expect(function () {
-                      expect(obj.data).to.be.jsonSchema(testCase.schema, 'expect() #' + i);
-                    }).to.throw(/(.+?\n){5,}/);
-                    expect(function () {
-                      obj.data.should.be.jsonSchema(testCase.schema, 'should #' + i);
-                    }).to.throw(/(.+?\n){5,}/);
-                  });
-                });
-              });
-            });
-          });
-        });
-        describe('tdd', function () {
-          it('is defined', function () {
-            assert.isFunction(assert.jsonSchema, 'jsonSchema');
-            assert.isFunction(assert.notJsonSchema, 'notJsonSchema');
-          });
-
-          Object.keys(tests).forEach(function (key) {
-            var testCase = tests[key];
-            describe(testCase.name + ' schema', function () {
-              it('assert.jsonSchema()', function () {
-                testCase.valid.forEach(function (obj, i) {
-                  assert.jsonSchema(obj.data, testCase.schema, '#' + i);
-                });
-              });
-              it('assert.notJsonSchema()', function () {
-                testCase.invalid.forEach(function (obj, i) {
-                  assert.notJsonSchema(obj.data, testCase.schema, '#' + i);
-                });
-              });
-
-              it('assert.jsonSchema() fails on invalid', function () {
-                testCase.invalid.forEach(function (obj, i) {
-                  expect(function () {
-                    assert.jsonSchema(obj.data, testCase.schema, '#' + i);
-                  }).to.fail('#' + i);
-                });
-              });
-
-              it('assert.notJsonSchema() fails on valid', function () {
-                testCase.valid.forEach(function (obj, i) {
-                  expect(function () {
-                    assert.notJsonSchema(obj.data, testCase.schema, '#' + i);
-                  }).to.fail('#' + i);
-                });
-              });
-              it('should/expect output single negation', function () {
-                testCase.invalid.forEach(function (obj, i) {
-                  expect(function () {
-                    assert.jsonSchema(obj.data, testCase.schema, '#' + i);
-                  }).to.throw(/(.+?\n){4}/);
-                });
-              });
-              describe('should/expect output multiple negation', function () {
-                before(function () {
-                  plugin.tv4.multiple = true;
-                });
-                after(function () {
-                  plugin.tv4.multiple = false;
-                });
-                it('should/expect multiple negation', function () {
-                  testCase.invalid.forEach(function (obj, i) {
-                    expect(function () {
-                      assert.jsonSchema(obj.data, testCase.schema, '#' + i);
-                    }).to.throw(/(.+?\n){5,}/);
-                  });
-                });
+                }).to.throw(/(.+?\n){5,}/);
               });
             });
           });
         });
       });
     });
-  }
-}());
+    describe('tdd', function () {
+      it('is defined', function () {
+        assert.isFunction(assert.jsonSchema, 'jsonSchema');
+        assert.isFunction(assert.notJsonSchema, 'notJsonSchema');
+      });
+
+      Object.keys(tests).forEach(function (key) {
+        const testCase = tests[key];
+        describe(testCase.name + ' schema', function () {
+          it('assert.jsonSchema()', function () {
+            testCase.valid.forEach(function (obj, i) {
+              assert.jsonSchema(obj.data, testCase.schema, '#' + i);
+            });
+          });
+          it('assert.notJsonSchema()', function () {
+            testCase.invalid.forEach(function (obj, i) {
+              assert.notJsonSchema(obj.data, testCase.schema, '#' + i);
+            });
+          });
+
+          it('assert.jsonSchema() fails on invalid', function () {
+            testCase.invalid.forEach(function (obj, i) {
+              expect(function () {
+                assert.jsonSchema(obj.data, testCase.schema, '#' + i);
+              }).to.fail('#' + i);
+            });
+          });
+
+          it('assert.notJsonSchema() fails on valid', function () {
+            testCase.valid.forEach(function (obj, i) {
+              expect(function () {
+                assert.notJsonSchema(obj.data, testCase.schema, '#' + i);
+              }).to.fail('#' + i);
+            });
+          });
+          it('should/expect output single negation', function () {
+            testCase.invalid.forEach(function (obj, i) {
+              expect(function () {
+                assert.jsonSchema(obj.data, testCase.schema, '#' + i);
+              }).to.throw(/(.+?\n){4}/);
+            });
+          });
+          describe('should/expect output multiple negation', function () {
+            before(function () {
+              tv4.multiple = true;
+            });
+            after(function () {
+              tv4.multiple = false;
+            });
+            it('should/expect multiple negation', function () {
+              testCase.invalid.forEach(function (obj, i) {
+                expect(function () {
+                  assert.jsonSchema(obj.data, testCase.schema, '#' + i);
+                }).to.throw(/(.+?\n){5,}/);
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Since we now require Node 20.x, we can safely switch to ESM only as all LTS of Node support `require(esm)`. This means CJS and ESM users can import or require the module either way.

For browsers, it is just expected they are running a bundler or module resolver anyway.

**This is a draft until we agree between ourselves that we're happy to drop direct browser support (i.e. users will need a build to run it in a browser, or an import map).**