### PR TITLE
fix(ci): allow same-version on release publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
           cache: "npm"
       - run: npm install -g npm@latest
       - run: npm ci --ignore-scripts
-      - run: npm version ${TAG_NAME} --git-tag-version=false
+      - run: npm version ${TAG_NAME} --git-tag-version=false --allow-same-version
         env:
           TAG_NAME: ${{ github.ref_name }}
       - run: npm publish --provenance --access public


### PR DESCRIPTION
## Problem

The publish workflow runs `npm version ${TAG_NAME} --git-tag-version=false` on a checkout of the release tag's tree. At a release tag, `package.json` already matches the tag version, so `npm version <tag>` errors with *"Version not changed"* and fails the `publish-npm` job before `npm publish` ever runs.

## Fix

Add `--allow-same-version` so the step is a no-op when the manifest already equals the tag, while still syncing the manifest if it ever diverges from the tag.

One-line change to `.github/workflows/publish.yml`.